### PR TITLE
Better error messages when a property is not found on source data

### DIFF
--- a/adapters/shp.py
+++ b/adapters/shp.py
@@ -4,6 +4,8 @@ import os
 import tempfile
 import shutil
 
+from property_transformation import get_transformed_properties
+
 import fiona
 from fiona.transform import transform_geom
 
@@ -70,10 +72,8 @@ def read(fp, prop_map, source_filename=None):
 
         for rec in source:
             transformed = _transformer(source.crs, rec)
-            transformed['properties'] = {
-                key: str(transformed['properties'][value])
-                for key, value in prop_map.iteritems()
-            }
+            transformed['properties'] = get_transformed_properties(
+                transformed['properties'], prop_map)
             collection['bbox'] = [
                 comparator(values)
                 for comparator, values in zip(

--- a/property_transformation.py
+++ b/property_transformation.py
@@ -1,0 +1,18 @@
+from types import UnicodeType, StringType
+
+class PropertyMappingFailedException(Exception):
+    pass
+
+def get_transformed_properties(source_properties, prop_map):
+    results = {}
+    for key, value in prop_map.iteritems():
+        if type(value) in (StringType, UnicodeType):
+            if value in source_properties:
+                results[key] = source_properties[value]
+            else:
+                raise PropertyMappingFailedException("property %s not found in source feature" % 
+                    (value))
+        else:
+            raise PropertyMappingFailedException("Unhandled mapping for key:%s value type:%s" % 
+                (key, type(value)))
+    return results


### PR DESCRIPTION
Also splits out the property mapping into a function that can be used across multiple source adapters, and lays the ground work for more complex mapping and static fields(see #10).
