### PR TITLE
Add support for filtering expressions in source definitions

### DIFF
--- a/adapters/shp.py
+++ b/adapters/shp.py
@@ -38,7 +38,7 @@ def _transformer(crs, feat):
     return feat
 
 
-def read(fp, prop_map, source_filename=None):
+def read(fp, prop_map, filterer=None, source_filename=None):
     """Read shapefile.
 
     :param fp: file-like object
@@ -72,6 +72,10 @@ def read(fp, prop_map, source_filename=None):
 
         for rec in source:
             transformed = _transformer(source.crs, rec)
+            if filterer is not None and not filterer.keep(transformed):
+                print "Skipping feature"
+                continue
+
             transformed['properties'] = get_transformed_properties(
                 transformed['properties'], prop_map)
             collection['bbox'] = [

--- a/filters.py
+++ b/filters.py
@@ -1,32 +1,46 @@
 from types import UnicodeType, StringType
+import re
 
 class FilteringFailedException(Exception):
     pass
 
 class BasicFilterer(object):
     """Filter that reads in a dictionary and filters based on feature properties"""
-    def __init__(self, filter_def):
+    def __init__(self, filter_def, filter_operator):
         super(BasicFilterer, self).__init__()
         self.filter_def = filter_def
-        self.operator = filter_def.get('operator', 'and')
-        if 'operator' in filter_def:
-            del filter_def['operator']
+        self.operator = filter_operator
+        if not self.operator in ['and', 'or']:
+            raise FilteringFailedException("Unknown filter operator:%s" % 
+                filter_operator)
 
     def keep(self, feature):
-        for key, value in self.filter_def.iteritems():
-            if type(value) in (StringType, UnicodeType):
-                if value == "not null":
-                    test_success = key in feature['properties'] and \
-                        feature['properties'][key] is not None
-                else:
-                    raise FilteringFailedException("Unhandled filtering operator key:%s value:%s" % 
+        for item in self.filter_def:
+            if not 'expression' in item:
+                raise FilteringFailedException("Expression missing from filter definition" % 
                         (key, value))
+            if item['expression'] == "not null":
+                test_success = item['key'] in feature['properties'] and \
+                    feature['properties'][item['key']] is not None
+            elif item['expression'] == "=":
+                test_success = item['key'] in feature['properties'] and \
+                    feature['properties'][item['key']] == item['value']
+            elif item['expression'] == "!=":
+                test_success = item['key'] not in feature['properties'] or \
+                    feature['properties'][item['key']] != item['value']
+            elif item['expression'] == "match":
+                test_success = item['key'] in feature['properties'] and \
+                    re.match(item['value'], feature['properties'][item['key']])
             else:
-                raise FilteringFailedException("Unhandled filtering for key:%s value type:%s" % 
-                    (key, type(value)))
+                raise FilteringFailedException("Unhandled filtering expression:%s" % 
+                    (item['expression']))
 
             if self.operator == 'and' and not test_success:
                 return False
             elif self.operator == 'or' and test_success:
                 return True
-        return True
+        
+        if self.operator == 'or':
+            return False
+        else:
+            return True

--- a/filters.py
+++ b/filters.py
@@ -1,0 +1,32 @@
+from types import UnicodeType, StringType
+
+class FilteringFailedException(Exception):
+    pass
+
+class BasicFilterer(object):
+    """Filter that reads in a dictionary and filters based on feature properties"""
+    def __init__(self, filter_def):
+        super(BasicFilterer, self).__init__()
+        self.filter_def = filter_def
+        self.operator = filter_def.get('operator', 'and')
+        if 'operator' in filter_def:
+            del filter_def['operator']
+
+    def keep(self, feature):
+        for key, value in self.filter_def.iteritems():
+            if type(value) in (StringType, UnicodeType):
+                if value == "not null":
+                    test_success = key in feature['properties'] and \
+                        feature['properties'][key] is not None
+                else:
+                    raise FilteringFailedException("Unhandled filtering operator key:%s value:%s" % 
+                        (key, value))
+            else:
+                raise FilteringFailedException("Unhandled filtering for key:%s value type:%s" % 
+                    (key, type(value)))
+
+            if self.operator == 'and' and not test_success:
+                return False
+            elif self.operator == 'or' and test_success:
+                return True
+        return True

--- a/process.py
+++ b/process.py
@@ -6,7 +6,7 @@ import click
 
 import adapters
 import utils
-
+from filters import BasicFilterer
 
 @click.command()
 @click.argument('sources', type=click.Path(exists=True), required=True)
@@ -49,9 +49,16 @@ def process(sources, output, force):
 
         utils.info('Reading', urlfile)
 
+        if 'filter' in source:
+            filterer = BasicFilterer(source['filter'])
+        else:
+            filterer = None
+
         try:
             geojson = getattr(adapters, source['filetype'])\
-                .read(fp, source['properties'], source_filename=source.get("filenameInZip", None))
+                .read(fp, source['properties'],
+                    filterer=filterer,
+                    source_filename=source.get("filenameInZip", None))
         except IOError:
             utils.error('Failed to read', urlfile)
             continue

--- a/process.py
+++ b/process.py
@@ -50,7 +50,7 @@ def process(sources, output, force):
         utils.info('Reading', urlfile)
 
         if 'filter' in source:
-            filterer = BasicFilterer(source['filter'])
+            filterer = BasicFilterer(source['filter'], source.get('filter_operator', 'and'))
         else:
             filterer = None
 


### PR DESCRIPTION
Example filter:

```
    "filter": [
        {
            "key": "DISTRICT",
            "expression": "not null"
        },
        {
            "key": "NAME",
            "expression": "match",
            "value": "\\d+"
        }
    ]
```
