### PR TITLE
Don't use an s3 download cache

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -121,6 +121,11 @@ def download(url):
 
     fp.close()
 
+    if cache_path:
+        if not os.path.exists(download_cache):
+            os.makedirs(download_cache)
+            shutil.copy(fp.name, cache_path)
+
     return fp
 
 

--- a/utils.py
+++ b/utils.py
@@ -86,6 +86,18 @@ def download(url):
 
     fp = tempfile.NamedTemporaryFile("wb", suffix=extension, delete=False)
 
+    download_cache = os.getenv("DOWNLOAD_CACHE")
+    cache_path = None
+    if download_cache is not None:
+        cache_path = os.path.join(
+            download_cache, hashlib.sha224(url.encode()).hexdigest()
+        )
+        if os.path.exists(cache_path):
+            logging.info("Returning %s from local cache at %s" % (url, cache_path))
+            fp.close()
+            shutil.copy(cache_path, fp.name)
+            return fp
+
     if parsed_url.scheme == "http" or parsed_url.scheme == "https":
         res = requests.get(url, stream=True, verify=False)
 


### PR DESCRIPTION
We have experienced issues where manually processed data needs to be fixed and reuploaded to S3. However, this download cache will return the original version forever.

Perhaps it would be better to set an expiration header or expiration policy on the download cache to ensure stale data is not used.

Here is an example from a deploy log:

````
16:57:57 [INFO] - Found https://data.openbounds.org.s3.amazonaws.com/USAHunting/manual-downloads/walk-in-2019-a.zip in s3 cache at s3://data.openbounds.org/downloadcache/7ec3068ff34f97e1d56d12d9497173d38fd55e916a39c41edbd1c65c
16:57:57 [ERROR] - Failed to read walk-in-2019-a.zip no such file or directory: '/tmp/tmpx0yfqf3n/MT_bma.shp'
````

Related: https://github.com/trailbehind/HuntingData/issues/51
