### PR TITLE
Only use download cache for remote sources

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -100,7 +100,7 @@ def download(url):
 
     s3_cache_bucket = os.getenv("S3_CACHE_BUCKET")
     s3_cache_key = None
-    if s3_cache_bucket is not None:
+    if s3_cache_bucket is not None and s3_cache_bucket not in url:
         s3_cache_key = (
             os.getenv("S3_CACHE_PREFIX", "") + hashlib.sha224(url.encode()).hexdigest()
         )
@@ -115,7 +115,6 @@ def download(url):
             return fp
         except:
             pass
-    #            logging.exception("error downloading cache file from s3")
 
     if parsed_url.scheme == "http" or parsed_url.scheme == "https":
         res = requests.get(url, stream=True, verify=False)


### PR DESCRIPTION
We have experienced issues where manually processed data needs to be fixed and reuploaded to S3. However, the download cache will return the original version forever.

This PR modifies the fetching of data files so that files from the same bucket are never cached. Additionally, we should set up an expiration policy on the folder `downloadcache` to remove objects after some amount of time (30 days?)

Related to trailbehind/HuntingData#51